### PR TITLE
Optional duration filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,9 +121,10 @@ var _authorWhitelistWordsFilter = function(video, title) {
 
 /**
  * Filter a video based on its duration
- * @param  object video The video object as it is being return by youtube-search
- * @param  string title The actual title after which has been searched
- * @return float        The score between 0 and 5
+ * @param  object video    The video object as it is being return by youtube-search
+ * @param  string title    The actual title after which has been searched
+ * @param  string duration The actual duration after which has been searched
+ * @return float           The score between 0 and 5
  */
 var _videoDurationFilter = function(video, title, duration) {
   var videoDuration = parseFloat(video.duration) * 1000;


### PR DESCRIPTION
PR for #6 

I added an optional parameter to `findBestMusicVideo`, so the API is now  
`#findBestMusicVideo(title, [duration], callback)`  
`duration` is in `ms`

example:

``` javascript
youtubeBestVideo.findBestMusicVideo('keeno moonrise', 408685, console.log)
```

---

I took the liberty of having the score from 0 to 5 instead of 0 to 1 like the other filters. I did some tests and a max score of 1 never bumped the song i wanted to the top.
